### PR TITLE
Add signal trace events for Lwt_condition

### DIFF
--- a/src/core/lwt.ml
+++ b/src/core/lwt.ml
@@ -225,6 +225,20 @@ external wakener_repr : 'a u -> 'a thread_repr = "%identity"
    being cleaned: *)
 let max_removed = 42
 
+(** Change the tracing context temporarily to another thread. *)
+let as_thread tid fn =
+  let (_, old_tid) as old_data = !current_data in
+  try
+    current_data := (Int_map.empty, tid);
+    Lwt_tracing.(!tracer.note_signal) old_tid;
+    let r = fn () in
+    switch_to_thread old_data;
+    r
+  with ex ->
+    switch_to_thread old_data;
+    raise ex
+
+
 (* +-----------------------------------------------------------------+
    | Restarting/connecting threads                                   |
    +-----------------------------------------------------------------+ *)
@@ -623,16 +637,16 @@ let temp_many l thread_type =
                     cancel_handlers = Chs_empty }
   }
 
-let wait_aux () = {
-  tid = next_id Wait;
+let wait_aux ?(thread_type=Wait) () = {
+  tid = next_id thread_type;
   state = Sleep { cancel = Cancel_no;
                   waiters = Empty;
                   removed = 0;
                   cancel_handlers = Chs_empty }
 }
 
-let wait () =
-  let t = wait_aux () in
+let wait ?thread_type () =
+  let t = wait_aux ?thread_type () in
   (thread t, wakener t)
 
 let task_aux () = {

--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -249,7 +249,7 @@ val async_exception_hook : (exn -> unit) ref
 type 'a u
   (** The type of thread wakeners. *)
 
-val wait : unit -> 'a t * 'a u
+val wait : ?thread_type:Lwt_tracing.thread_type -> unit -> 'a t * 'a u
   (** [wait ()] is a pair of a thread which sleeps forever (unless it
       is resumed by one of the functions [wakeup], [wakeup_exn] below)
       and the corresponding wakener.  This thread does not block the
@@ -453,3 +453,7 @@ val backtrace_finalize : (exn -> exn) -> (unit -> 'a t) -> (unit -> unit t) -> '
 
 val id_of_thread : 'a t -> Lwt_tracing.thread_id
 val current_id : unit -> Lwt_tracing.thread_id
+
+(** Change the tracing context temporarily to another thread.
+ * A signal from the previous thread to the new one is reported. *)
+val as_thread : Lwt_tracing.thread_id -> (unit -> 'a) -> 'a

--- a/src/core/lwt_condition.ml
+++ b/src/core/lwt_condition.ml
@@ -31,12 +31,18 @@
 
 let (>>=) = Lwt.(>>=)
 
-type 'a t = ('a Lwt.u Lwt_sequence.t * string option)
+type 'a t = ('a Lwt.u Lwt_sequence.t * Lwt_tracing.thread_id * string option)
 
-let create ?label () = (Lwt_sequence.create (), label)
+let create ?label () =
+  (* Create a dummy thread to link all the task threads together. *)
+  let trace_thread = Lwt.id_of_thread (fst (Lwt.wait ~thread_type:Lwt_tracing.Condition ())) in
+  begin match label with
+  | None -> ()
+  | Some label -> Lwt_tracing.(!tracer.note_label) trace_thread label end;
+  (Lwt_sequence.create (), trace_thread, label)
 
-let wait ?mutex (cvar, label) =
-  let waiter = Lwt.add_task_r ~thread_type:Lwt_tracing.Condition cvar in
+let wait ?mutex (cvar, trace_thread, label) =
+  let waiter = Lwt.as_thread trace_thread (fun () -> Lwt.add_task_r cvar) in
   begin match label with
   | None -> ()
   | Some label -> Lwt_tracing.(!tracer.note_label) (Lwt.id_of_thread waiter) label end;
@@ -52,13 +58,15 @@ let wait ?mutex (cvar, label) =
          | Some m -> Lwt_mutex.lock m
          | None -> Lwt.return_unit)
 
-let signal (cvar, _) arg =
+let signal (cvar, trace_thread, _) arg =
   try
-    Lwt.wakeup_later (Lwt_sequence.take_l cvar) arg
+    Lwt.as_thread trace_thread (fun () -> Lwt.wakeup_later (Lwt_sequence.take_l cvar) arg)
   with Lwt_sequence.Empty ->
     ()
 
-let broadcast (cvar, _) arg =
+let broadcast (cvar, trace_thread, _) arg =
   let wakeners = Lwt_sequence.fold_r (fun x l -> x :: l) cvar [] in
   Lwt_sequence.iter_node_l Lwt_sequence.remove cvar;
-  List.iter (fun wakener -> Lwt.wakeup_later wakener arg) wakeners
+  Lwt.as_thread trace_thread (fun () ->
+    List.iter (fun wakener -> Lwt.wakeup_later wakener arg) wakeners
+  )

--- a/src/tracing/lwt_tracing.ml
+++ b/src/tracing/lwt_tracing.ml
@@ -37,6 +37,7 @@ type tracer = {
   note_created : thread_id -> thread_type -> unit;
   note_read : thread_id -> unit;
   note_resolved : thread_id -> ex:exn option -> unit;
+  note_signal : thread_id -> unit;
   note_becomes : thread_id -> thread_id -> unit;
   note_label : thread_id -> string -> unit;
   note_switch : unit -> unit;
@@ -48,6 +49,7 @@ let null_tracer =
     note_created = ignore2;
     note_read = ignore;
     note_resolved = (fun _ ~ex:_ -> ());
+    note_signal = ignore;
     note_becomes = ignore2;
     note_label = ignore2;
     note_switch = ignore;

--- a/src/tracing/lwt_tracing.mli
+++ b/src/tracing/lwt_tracing.mli
@@ -45,13 +45,18 @@ type tracer = {
   (** [note_created p] indicates when a new thread is created. *)
 
   note_read : thread_id -> unit;
-  (** [note_reads p] indicates that the current thread read the resolution of p.
+  (** [note_read p] indicates that the current thread read the resolution of p.
    * e.g. we were waiting for p and p has become resolved.
    * [note_read] implies [note_switch], even if it's not sent, so check [current_id]. *)
 
   note_resolved : thread_id -> ex:exn option -> unit;
   (** [note_resolves p] indicates that [p] has been resolved (woken).
    * If it resolved to failure, the exception is given too. *)
+
+  note_signal : thread_id -> unit;
+  (** [note_signal source] indicates that [source] has signalled the (new) current thread
+   * (e.g. with [Lwt_condition.signal].
+   * As with [note_read], this implies a switch. *)
 
   note_becomes : thread_id -> thread_id -> unit;
   (** [note_becomes p1 p2] indicates that the previously-unresolved p1 now behaves as p2. *)


### PR DESCRIPTION
Note: this will break the current mirage-profile v0.3 when compiled with profiling enabled. I'll make a new release soon, but you can pin the Git version until then to fix it.

The new version will be slightly less tightly coupled.
