### PR TITLE
Record what a thread is waiting on

### DIFF
--- a/src/tracing/lwt_tracing.ml
+++ b/src/tracing/lwt_tracing.ml
@@ -32,6 +32,11 @@ type thread_type =
   | Join
   | Map
   | Condition
+  | On_success
+  | On_failure
+  | On_termination
+  | On_any
+  | Ignore_result
 
 type tracer = {
   note_created : thread_id -> thread_type -> unit;

--- a/src/tracing/lwt_tracing.ml
+++ b/src/tracing/lwt_tracing.ml
@@ -35,6 +35,7 @@ type thread_type =
 
 type tracer = {
   note_created : thread_id -> thread_type -> unit;
+  note_try_read : thread_id -> thread_id -> unit;
   note_read : thread_id -> unit;
   note_resolved : thread_id -> ex:exn option -> unit;
   note_signal : thread_id -> unit;
@@ -47,6 +48,7 @@ type tracer = {
 let null_tracer =
   let ignore2 _ _ = () in {
     note_created = ignore2;
+    note_try_read = ignore2;
     note_read = ignore;
     note_resolved = (fun _ ~ex:_ -> ());
     note_signal = ignore;

--- a/src/tracing/lwt_tracing.mli
+++ b/src/tracing/lwt_tracing.mli
@@ -39,6 +39,11 @@ type thread_type =
   | Join
   | Map
   | Condition
+  | On_success
+  | On_failure
+  | On_termination
+  | On_any
+  | Ignore_result
 
 type tracer = {
   note_created : thread_id -> thread_type -> unit;

--- a/src/tracing/lwt_tracing.mli
+++ b/src/tracing/lwt_tracing.mli
@@ -44,6 +44,9 @@ type tracer = {
   note_created : thread_id -> thread_type -> unit;
   (** [note_created p] indicates when a new thread is created. *)
 
+  note_try_read : thread_id -> thread_id -> unit;
+  (** [note_try_read th p] indicates that [th] checked the state of [p] and found it was sleeping. *)
+
   note_read : thread_id -> unit;
   (** [note_read p] indicates that the current thread read the resolution of p.
    * e.g. we were waiting for p and p has become resolved.


### PR DESCRIPTION
This records when a thread tries to read another but it isn't resolved yet. This makes it easier to find out why a thread never resolved.

This PR also adds some new thread types. These aren't used yet, but having them allows mirage-profile to be updated to understand them first (my `tracing-async` branch makes use of them).
