### PR TITLE
Support tracing for Lwt.async

### DIFF
--- a/src/core/lwt.mli
+++ b/src/core/lwt.mli
@@ -516,6 +516,6 @@ val abandon_wakeups : unit -> unit
 val id_of_thread : 'a t -> Lwt_tracing.thread_id
 val current_id : unit -> Lwt_tracing.thread_id
 
+val as_thread : Lwt_tracing.thread_id -> signal:bool -> (unit -> 'a) -> 'a
 (** Change the tracing context temporarily to another thread.
- * A signal from the previous thread to the new one is reported. *)
-val as_thread : Lwt_tracing.thread_id -> (unit -> 'a) -> 'a
+    If [signal] is [true], a signal from the previous thread to the new one is reported. *)

--- a/src/tracing/lwt_tracing.ml
+++ b/src/tracing/lwt_tracing.ml
@@ -37,6 +37,7 @@ type thread_type =
   | On_termination
   | On_any
   | Ignore_result
+  | Async
 
 type tracer = {
   note_created : thread_id -> thread_type -> unit;

--- a/src/tracing/lwt_tracing.mli
+++ b/src/tracing/lwt_tracing.mli
@@ -44,6 +44,7 @@ type thread_type =
   | On_termination
   | On_any
   | Ignore_result
+  | Async
 
 type tracer = {
   note_created : thread_id -> thread_type -> unit;


### PR DESCRIPTION
Treat `Lwt.async` as creating a new thread and show operations it performs as belonging to that thread. This is useful when tracking down uncaught exceptions, as when an async function raises an exception you can now see which thread spawned the async operation in the first place.

(should be applied on top on #11)