### PR TITLE
Move opam to opam/opam

### DIFF
--- a/opam/opam
+++ b/opam/opam
@@ -1,6 +1,6 @@
 opam-version: "1.2"
 name: "lwt"
-version: "dev"
+version: "2.6.0"
 maintainer: "Anton Bachin <antonbachin@yahoo.com>"
 authors: [
   "Jérôme Vouillon"


### PR DESCRIPTION
Stops opam 1.x trying to treat it as an overlay.

Also, add version number to get correct conflicts.

/cc @yomimono 

See: https://github.com/ocaml/opam/issues/2818#issuecomment-273780768