### PR TITLE
cppo_ocamlbuild is now a separate package

### DIFF
--- a/opam/opam
+++ b/opam/opam
@@ -37,6 +37,7 @@ depends: [
   "ocamlbuild" {build}
   "result"
   "cppo" {build}
+  "cppo_ocamlbuild" {build}
   # See https://github.com/ocsigen/lwt/issues/266
   ( "base-no-ppx" | "ppx_tools" {build} )
   ## OASIS is not required in released version


### PR DESCRIPTION
Hopefully fixes https://github.com/mirage/mirage-skeleton/issues/237.